### PR TITLE
Fix PARTITION_INFORMATION_GPT structure (in according to pinvoke)

### DIFF
--- a/DemoApplication/Program.cs
+++ b/DemoApplication/Program.cs
@@ -81,7 +81,7 @@ namespace DemoApplication
         {
             const string drive = @"\\.\C:";
 
-            Console.WriteLine(@"## Exmaple on {0} ##", drive);
+            Console.WriteLine(@"## Example on {0} ##", drive);
             SafeFileHandle hddHandle = CreateFile(drive, FileAccess.Read, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
 
             if (hddHandle.IsInvalid)
@@ -113,7 +113,7 @@ namespace DemoApplication
         {
             const string device = @"\\.\MountPointManager";
 
-            Console.WriteLine(@"## Exmaple on {0} ##", device);
+            Console.WriteLine(@"## Example on {0} ##", device);
             SafeFileHandle deviceHandle = CreateFile(device, FileAccess.Read, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
 
             if (deviceHandle.IsInvalid)
@@ -153,7 +153,7 @@ namespace DemoApplication
         {
             const string drive = @"\\.\PhysicalDrive0";
 
-            Console.WriteLine(@"## Exmaple on {0} ##", drive);
+            Console.WriteLine(@"## Example on {0} ##", drive);
             SafeFileHandle hddHandle = CreateFile(drive, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
 
             if (hddHandle.IsInvalid)
@@ -193,7 +193,7 @@ namespace DemoApplication
         {
             const string drive = @"\\.\C:";
 
-            Console.WriteLine(@"## Exmaple on {0} ##", drive);
+            Console.WriteLine(@"## Example on {0} ##", drive);
             SafeFileHandle volumeHandle = CreateFile(drive, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
 
             if (volumeHandle.IsInvalid)
@@ -304,7 +304,7 @@ namespace DemoApplication
             const string file = @"C:\Windows\system32\cmd.exe";
             string drive = @"\\.\" + Directory.GetDirectoryRoot(file).Substring(0, 2);
 
-            Console.WriteLine(@"## Exmaple on {0} on drive {1} ##", file, drive);
+            Console.WriteLine(@"## Example on {0} on drive {1} ##", file, drive);
 
             // Open file to defragment
             SafeFileHandle fileHandle = CreateFile(file, FileAccess.Read, FileShare.ReadWrite, IntPtr.Zero,
@@ -412,7 +412,7 @@ namespace DemoApplication
             const string dir = @"C:\Windows";
             string drive = @"\\.\" + Directory.GetDirectoryRoot(dir).Substring(0, 2);
 
-            Console.WriteLine(@"## Exmaple on {0} on drive {1} ##", dir, drive);
+            Console.WriteLine(@"## Example on {0} on drive {1} ##", dir, drive);
 
             // Open volume to defragment on
             SafeFileHandle driveHandle = CreateFile(drive, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero,
@@ -560,7 +560,7 @@ namespace DemoApplication
         {
             const string drive = @"\\.\CdRom0";
 
-            Console.WriteLine(@"## Exmaple on {0} ##", drive);
+            Console.WriteLine(@"## Example on {0} ##", drive);
             SafeFileHandle cdTrayHandle = CreateFile(drive, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
 
             if (cdTrayHandle.IsInvalid)
@@ -595,7 +595,7 @@ namespace DemoApplication
         {
             const string drive = @"\\.\C:";
 
-            Console.WriteLine(@"## Exmaple on {0} ##", drive);
+            Console.WriteLine(@"## Example on {0} ##", drive);
             SafeFileHandle volumeHandle = CreateFile(drive, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
 
             if (volumeHandle.IsInvalid)
@@ -662,7 +662,7 @@ namespace DemoApplication
                     fs.Write(data, 0, data.Length);
                 }
 
-                Console.WriteLine(@"## Exmaple with {0} ##", file);
+                Console.WriteLine(@"## Example with {0} ##", file);
                 SafeFileHandle fileHandle = CreateFile(file, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
 
                 if (fileHandle.IsInvalid)
@@ -727,7 +727,7 @@ namespace DemoApplication
                     }
                 }
 
-                Console.WriteLine(@"## Exmaple with {0} ##", file);
+                Console.WriteLine(@"## Example with {0} ##", file);
                 SafeFileHandle fileHandle = CreateFile(file, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
 
                 if (fileHandle.IsInvalid)

--- a/DeviceIOControlLib/Objects/Disk/PARTITION_INFORMATION_GPT.cs
+++ b/DeviceIOControlLib/Objects/Disk/PARTITION_INFORMATION_GPT.cs
@@ -4,17 +4,13 @@ using DeviceIOControlLib.Objects.Enums;
 
 namespace DeviceIOControlLib.Objects.Disk
 {
-    [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Unicode)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct PARTITION_INFORMATION_GPT
     {
-        [FieldOffset(0)]
         public Guid PartitionType;
-        [FieldOffset(16)]
         public Guid PartitionId;
-        [FieldOffset(32)]
         [MarshalAs(UnmanagedType.U8)]
         public EFIPartitionAttributes Attributes;
-        [FieldOffset(40)]
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 36)]
         public string Name;
     }


### PR DESCRIPTION
Fix PARTITION_INFORMATION_GPT structure according to [https://www.pinvoke.net/default.aspx/Structures/PARTITION_INFORMATION_GPT.html](url). Works better for my case, for example I get correct partitionType Guid = ebd0a0a2-b9e5-4433-87c0-68b6b72699c7 instead of wrong eb0101a2-b9e5-4433-87c0-68b6b72699c7.